### PR TITLE
add note for make prompt need ffmpeg

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -40,6 +40,9 @@ git clone https://github.com/Plachtaa/VALL-E-X.git
 cd VALL-E-X
 pip install -r requirements.txt
 ```
+
+> 注意：如果需要制作prompt，需要安装 ffmpeg 并将其所在文件夹加入到环境变量PATH中
+
 ##  🎧 在线Demo
 如果你不想在本地安装，你可以在线体验VALL-E X的功能，点击下面的任意一个链接即可开始体验。
 <br>

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ git clone https://github.com/Plachtaa/VALL-E-X.git
 cd VALL-E-X
 pip install -r requirements.txt
 ```
+
+> Note: If you want to make prompt, you need to install ffmpeg and add its folder to the environment variable PATH.
+
 ##  🎧 Demos
 Not ready to set up the environment on your local machine just yet? No problem! We've got you covered with our online demos. You can try out VALL-E X directly on Hugging Face or Google Colab, experiencing the model's capabilities hassle-free!
 <br>


### PR DESCRIPTION
如果环境里没有ffmpeg然后make prompt，会报错 `Couldn't find ffprobe or avprobe - defaulting to ffprobe, but may not work`，安装后即可解决