### PR TITLE
Replace Encodec decoding with Vocos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ matplotlib
 gradio
 nltk
 sudachipy
+vocos


### PR DESCRIPTION
This PR replaces the Encodec decoding with Vocos (https://github.com/charactr-platform/vocos).

  
In "utils/generation.py" file, `generate_audio` and `generate_audio_from_long_text` now both use Vocos decoding.

The dependency on Encodec isn't able to be fully replaced because Vocos doesn't have a way to encode.

My limited testing with a 4090 indicates that Vocos decoding is just marginally slower than Encodec decoding, but the increase in quality more than makes up for it I think.

  
I am attaching some generated audio samples so you can hear the difference the new decoder makes. This PR does not implement upsampling from 24k to 44.1k as recommended by the Vocos examples, but I have included a few generations that were upsampled to 44.1k in the samples zip.

[samples.zip](https://github.com/Plachtaa/VALL-E-X/files/12448786/samples.zip)
