### PR TITLE
fix name 'cleaners' is not defined

### DIFF
--- a/utils/g2p/__init__.py
+++ b/utils/g2p/__init__.py
@@ -65,7 +65,7 @@ def sequence_to_text(sequence):
 
 def _clean_text(text, cleaner_names):
   for name in cleaner_names:
-    cleaner = getattr(cleaners, name)
+    cleaner = getattr(utils.g2p.cleaners, name)
     if not cleaner:
       raise Exception('Unknown cleaner: %s' % name)
     text, langs = cleaner(text)


### PR DESCRIPTION
When I try to test the model using codes in 🪑 Basics, I came across an error. It can be fixed after changing the code in `__init__.py`

```     66 def _clean_text(text, cleaner_names):
     67   for name in cleaner_names:
---> 68     cleaner = getattr(cleaners, name)
     69     if not cleaner:
     70       raise Exception('Unknown cleaner: %s' % name)

NameError: name 'cleaners' is not defined```