### PR TITLE
share=True so colab users can use inference ui

### DIFF
--- a/launch-ui.py
+++ b/launch-ui.py
@@ -615,7 +615,7 @@ def main():
                               outputs=[text_output_4, audio_output_4])
 
     webbrowser.open("http://127.0.0.1:7860")
-    app.launch()
+    app.launch(share=True)
 
 if __name__ == "__main__":
     formatter = (


### PR DESCRIPTION
Current rendition only has localhost link which does not allow people using colab or paperspace to use the webui